### PR TITLE
change url to correctly show the picture

### DIFF
--- a/custom_components/weather_data/sensor.py
+++ b/custom_components/weather_data/sensor.py
@@ -144,8 +144,8 @@ class WeatherSensor(Entity):
         if self.type != "symbol":
             return None
         return (
-            "https://api.met.no/weatherapi/weathericon/1.1/"
-            f"?symbol={self._state}.png;content_type=image/png"
+            "https://api.met.no/images/weathericons/"
+            f"png/{self._state}.png"
         )
 
     @property


### PR DESCRIPTION
this fixes #17 and fixes #19 , still using url from api.met.no .

an example of what I get with this change on my installation:
![image](https://user-images.githubusercontent.com/842026/114311486-4034de80-9aef-11eb-9e92-52571e2e4bd1.png)
