### PR TITLE
removed device_state_attributes

### DIFF
--- a/custom_components/weather_data/sensor.py
+++ b/custom_components/weather_data/sensor.py
@@ -128,9 +128,9 @@ class WeatherSensor(Entity):
         
         # changed property name since 2021.12
         if MAJOR_VERSION >= 2022 or (MAJOR_VERSION == 2021 and MINOR_VERSION == 12):
-            WeatherSensor.extra_state_attributes = property(lambda self: self.attrs)
+            WeatherSensor.extra_state_attributes = property(lambda: {ATTR_ATTRIBUTION: ATTRIBUTION})
         else:
-            WeatherSensor.device_state_attributes = property(lambda self: self.attrs)
+            WeatherSensor.device_state_attributes = property(lambda: {ATTR_ATTRIBUTION: ATTRIBUTION})
 
     @property
     def name(self):

--- a/custom_components/weather_data/sensor.py
+++ b/custom_components/weather_data/sensor.py
@@ -4,6 +4,8 @@ import logging
 from random import randrange
 from xml.parsers.expat import ExpatError
 
+from homeassistant.const import MAJOR_VERSION, MINOR_VERSION
+
 import aiohttp
 import async_timeout
 import voluptuous as vol
@@ -123,6 +125,12 @@ class WeatherSensor(Entity):
         self._state = None
         self._unit_of_measurement = SENSOR_TYPES[self.type][1]
         self._device_class = SENSOR_TYPES[self.type][2]
+        
+        # changed property name since 2021.12
+        if MAJOR_VERSION >= 2022 or (MAJOR_VERSION == 2021 and MINOR_VERSION == 12):
+            WeatherSensor.extra_state_attributes = property(lambda self: self.attrs)
+        else:
+            WeatherSensor.device_state_attributes = property(lambda self: self.attrs)
 
     @property
     def name(self):

--- a/custom_components/weather_data/sensor.py
+++ b/custom_components/weather_data/sensor.py
@@ -147,11 +147,6 @@ class WeatherSensor(Entity):
         return "https://api.met.no/images/weathericons/" f"png/{self._state}.png"
 
     @property
-    def device_state_attributes(self):
-        """Return the state attributes."""
-        return {ATTR_ATTRIBUTION: ATTRIBUTION}
-
-    @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
         return self._unit_of_measurement


### PR DESCRIPTION
since HA2021.12.dev0 , remove device_state_attributes to avoid warning 
`Entity sensor.weather_forecast_12h_symbol (<class 'custom_components.weather_data.sensor.WeatherSensor'>) implements device_state_attributes. Please report it to the custom component author`.